### PR TITLE
Added Proxy config value to proxy API calls, updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,11 @@ You can now use Namecheap API's sandbox mode within `namecheap-api`! Whenever us
 ```javascript
 namecheapApi.apiCall("SomeCommand", {}, true);
 ```
+
+## Web proxy
+
+`namecheap-api` uses the `request` module to make api calls which will obey the HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables.  To specify a specific proxy for Namecheap API calls only you can set the "Proxy" config variable.
+
+```javascript
+namecheapApi.config.set("Proxy", "http://user:pass@someproxy.com:80");
+```

--- a/namecheap/apiCall.js
+++ b/namecheap/apiCall.js
@@ -16,7 +16,7 @@
             throw new Error("CommandName is required and must be a string.");
         }
         if (requestParams && !lodash.isPlainObject(requestParams)) {
-            throw new Error("requestParams must be an object.");    
+            throw new Error("requestParams must be an object.");
         }
 
         var requestUrl = "https://api."+(sandbox?'sandbox.':'')+"namecheap.com/xml.response?",
@@ -33,7 +33,11 @@
         function promiseExecutor(resolve, reject) {
             async.waterfall([
                 function (callback) {
-                    request(requestUrl, function (error, response, body) {
+                    var r = request;
+                    if( providedConfig['Proxy'] != '' ){
+                      r = request.defaults({'proxy':providedConfig['Proxy']});
+                    }
+                    r(requestUrl, function (error, response, body) {
                         if (error && !body) {
                             return callback(error);
                         }
@@ -67,14 +71,14 @@
                     responseCode = responseErrors[0].Error[0].$.Number;
                     responseMessage = responseErrors[0].Error[0]._;
                     if (responseCode) {
-                        responseObject.response = new Error(responseCode + 
-                            ": " + responseMessage);  
+                        responseObject.response = new Error(responseCode +
+                            ": " + responseMessage);
                     } else {
                         responseObject.response = new Error(responseMessage);
                     }
                     return reject(responseObject);
                 }
-                
+
                 responseObject.response = result.ApiResponse.CommandResponse;
                 resolve(responseObject);
             });

--- a/namecheap/apiCall.js
+++ b/namecheap/apiCall.js
@@ -33,11 +33,11 @@
         function promiseExecutor(resolve, reject) {
             async.waterfall([
                 function (callback) {
-                    var r = request;
-                    if( providedConfig['Proxy'] != '' ){
-                      r = request.defaults({'proxy':providedConfig['Proxy']});
+                    var requestOptions = {
+                      url: requestUrl
                     }
-                    r(requestUrl, function (error, response, body) {
+                    if(providedConfig['Proxy'] != '') requestOptions.proxy = providedConfig['Proxy'];
+                    request(requestOptions, function (error, response, body) {
                         if (error && !body) {
                             return callback(error);
                         }

--- a/namecheap/config.js
+++ b/namecheap/config.js
@@ -1,51 +1,51 @@
 (function () {
     'use strict';
-    
+
     var lodash = require('lodash'),
-        
-        config = {},
-        requiredProperties = ['ApiUser', 'ApiKey', 'UserName', 'ClientIp'];
-    
+
+        config = { 'Proxy': '' },
+        requiredProperties = ['ApiUser', 'ApiKey', 'UserName', 'ClientIp', 'Proxy'];
+
     function set(configName, configValue) {
-        
+
         if (requiredProperties.indexOf(configName) === -1) {
             throw new Error("That is not a configurable property.");
         }
         if (!lodash.isString(configValue) || configValue.length === 0) {
-            throw new Error("Configurable property must have a string value."); 
+            throw new Error("Configurable property must have a string value.");
         }
-        
+
         if (['ApiUser', 'UserName'].indexOf(configName) > -1) {
             if (configName === "ApiUser" && !config.UserName) {
                 config.UserName = configValue;
             }
             if (configName === "UserName" && !config.ApiUser) {
-                config.ApiUser = configValue;   
+                config.ApiUser = configValue;
             }
         }
-        
+
         config[configName] = configValue;
     }
-    
+
     function get(globalName) {
         return config[globalName];
     }
-    
+
     function getAll() {
-        return lodash.clone(config);   
+        return lodash.clone(config);
     }
-    
+
     function isSatisfied() {
         return lodash.every(requiredProperties, function (requiredProperty) {
-            return config.hasOwnProperty(requiredProperty);   
+            return config.hasOwnProperty(requiredProperty);
         });
     }
-    
+
     module.exports = {
         set: set,
         get: get,
         getAll: getAll,
         isSatisfied: isSatisfied
     };
-    
+
 }());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namecheap-api",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Node.JS library for the Namecheap API",
   "main": "namecheap-api.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namecheap-api",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Node.JS library for the Namecheap API",
   "main": "namecheap-api.js",
   "scripts": {

--- a/tests/namecheap/config.spec.js
+++ b/tests/namecheap/config.spec.js
@@ -18,18 +18,21 @@ describe('config', function () {
             config.set("ApiKey", "Some-key");
             config.set("UserName", "SomeUser");
             config.set("ClientIp", "192.168.1.1");
+            config.set("Proxy", 'http://someproxyserver:8080');
         }).not.to.throw();
 
         expect(config.get("ApiUser")).to.equal("SomeUser");
         expect(config.get("ApiKey")).to.equal("Some-key");
         expect(config.get("UserName")).to.equal("SomeUser");
         expect(config.get("ClientIp")).to.equal("192.168.1.1");
+        expect(config.get("Proxy")).to.equal("http://someproxyserver:8080");
 
         expect(config.getAll()).to.deep.equal({
             ApiUser: "SomeUser",
             ApiKey: "Some-key",
             UserName: "SomeUser",
-            ClientIp: "192.168.1.1"
+            ClientIp: "192.168.1.1",
+            Proxy: "http://someproxyserver:8080"
         });
     });
 
@@ -72,10 +75,10 @@ describe('config', function () {
 
         expect(config.get("UserName")).to.equal("SomeUser");
     });
-    
+
     it("notifies if required configuration is satisfied", function () {
         expect(config.isSatisfied()).to.be.false;
-        
+
         config.set("ApiUser", "SomeUser");
         config.set("ApiKey", "SomeKey");
         config.set("ClientIp", "192.168.1.1");


### PR DESCRIPTION
Because Namecheap requires a whitelist of URL's and we are using Heroku we are forced to use a proxy to make API calls.   The solution seems to be using proxy addons like proximo and fixie which cost money and offer a limited number of calls.  Therefor I only want to proxy Namecheap API calls and allow the rest to go via the normal route.  

This update simply adds a 'Proxy' config variable with a default value of '' setting no proxy.  Before the API request it will read and use the value to set up the request() with a proxy before sending the call. 
 
https://elements.heroku.com/addons/proximo
https://elements.heroku.com/addons/fixie